### PR TITLE
Fix top level makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-REBAR?=./rebar
+REBAR?=rebar3
 
 all: build
 


### PR DESCRIPTION
This removes the dependency to the `rebar` binary and adds a dependency to an installed `rebar3` binary.

If this is not desired, the `rebar3` binary could be added to the repository like the `rebar` once was.